### PR TITLE
Issue override jaggedarray sum

### DIFF
--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -276,9 +276,15 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
     def islightlike(self, tolerance=1e-10):
         return awkward.util.numpy.absolute(self.mag2) < tolerance
 
+    def sum(self):
+        if isinstance(self, awkward.JaggedArray):
+            return TLorentzVectorArray.from_cartesian(self.x.sum(), self.y.sum(), self.z.sum(), self.t.sum())
+        else:
+            return TLorentzVector(self.x.sum(), self.y.sum(), self.z.sum(), self.t.sum())
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method != "__call__":
-            raise NotImplemented
+            return NotImplemented
 
         inputs = list(inputs)
         for i in range(len(inputs)):

--- a/uproot_methods/classes/TVector2.py
+++ b/uproot_methods/classes/TVector2.py
@@ -59,6 +59,12 @@ class ArrayMethods(Common, uproot_methods.common.TVector.ArrayMethods, uproot_me
     def y(self):
         return self["fY"]
 
+    def sum(self):
+        if isinstance(self, awkward.JaggedArray):
+            return TVector2Array.from_cartesian(self.x.sum(), self.y.sum())
+        else:
+            return TVector2(self.x.sum(), self.y.sum())
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method != "__call__":
             return NotImplemented

--- a/uproot_methods/classes/TVector3.py
+++ b/uproot_methods/classes/TVector3.py
@@ -150,9 +150,15 @@ class ArrayMethods(Common, uproot_methods.common.TVector.ArrayMethods, uproot_me
         out["fZ"] = z
         return out
 
+    def sum(self):
+        if isinstance(self, awkward.JaggedArray):
+            return TVector3Array.from_cartesian(self.x.sum(), self.y.sum(), self.z.sum())
+        else:
+            return TVector3(self.x.sum(), self.y.sum(), self.z.sum())
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method != "__call__":
-            raise NotImplemented
+            return NotImplemented
 
         inputs = list(inputs)
         for i in range(len(inputs)):

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
`jaggedarray.sum()` when the `jaggedarray` is a `TLorentzVector` (or `TVector3` or `TVector2`) failed because its `__array_ufunc__` doesn't implement `reduceat`. Instead of trying to wedge this in, we just override `sum()` in these methods to get exactly the right behavior.