### PR TITLE
Faster LorentzVector stuff

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -42,7 +42,7 @@ class Test(unittest.TestCase):
 
     def test_issue10(self):
         p4 = TLorentzVectorArray.from_ptetaphim(awkward.JaggedArray.fromiter([[1.0]]), awkward.JaggedArray.fromiter([[1.0]]), awkward.JaggedArray.fromiter([[1.0]]), awkward.JaggedArray.fromiter([[1.0]]))
-        assert p4.mass.tolist() == [[0.9999999999999999]]
+        assert p4.mass.tolist() == [[1.0]]
         assert p4[0].mass.tolist() == [0.9999999999999999]
         assert p4[0][0].mass == 0.9999999999999999
         assert type(p4.mass) is awkward.JaggedArray

--- a/uproot_methods/base.py
+++ b/uproot_methods/base.py
@@ -58,6 +58,14 @@ def _unwrap_jagged(ArrayMethods, arrays):
         wrap, arrays = _unwrap_jagged(ArrayMethods, [x.content for x in arrays])
         return lambda x: JaggedArrayMethods(starts, stops, wrap(x)), arrays
 
+def memo(function):
+    memoname = "_memo_" + function.__name__
+    def memofunction(self):
+        if not hasattr(self, memoname):
+            setattr(self, memoname, function(self))
+        return getattr(self, memoname)
+    return memofunction
+
 class ROOTMethods(awkward.Methods):
     _arraymethods = None
 

--- a/uproot_methods/base.py
+++ b/uproot_methods/base.py
@@ -51,12 +51,12 @@ def _normalize_arrays(arrays):
 
 def _unwrap_jagged(ArrayMethods, arrays):
     if not isinstance(arrays[0], awkward.JaggedArray):
-        return lambda x: x, arrays
+        return lambda x: x, lambda x: x, arrays
     else:
         JaggedArrayMethods = ArrayMethods.mixin(ArrayMethods, awkward.JaggedArray)
         starts, stops = arrays[0].starts, arrays[0].stops
-        wrap, arrays = _unwrap_jagged(ArrayMethods, [x.content for x in arrays])
-        return lambda x: JaggedArrayMethods(starts, stops, wrap(x)), arrays
+        wrapmethods, wrap, arrays = _unwrap_jagged(ArrayMethods, [x.content for x in arrays])
+        return lambda x: JaggedArrayMethods(starts, stops, wrapmethods(x)), lambda x: awkward.JaggedArray(starts, stops, wrap(x)), arrays
 
 def memo(function):
     memoname = "_memo_" + function.__name__

--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -202,7 +202,7 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
 
     @property
     def eta(self):
-        return -awkward.util.numpy.log((1.0 - awkward.util.numpy.cos(self.theta)) / (1.0 + awkward.util.numpy.cos(self.theta))) / 2.0
+        return awkward.util.numpy.arcsinh(self.z / self.p3.rho)
 
     @property
     def rapidity(self):
@@ -374,7 +374,7 @@ class Methods(Common, uproot_methods.base.ROOTMethods):
 
     @property
     def eta(self):
-        return -math.log((1.0 - math.cos(self.theta)) / (1.0 + math.cos(self.theta)))/2.0
+        return math.asinh(self.z / self.p3.rho)
 
     @property
     def rapidity(self):

--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -559,45 +559,54 @@ class TLorentzVectorArray(ArrayMethods, awkward.ObjectArray):
 
     @classmethod
     def from_p3(cls, p3, t):
-        wrap, (x, y, z, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((p3.x, p3.y, p3.z, t)))
-        return wrap(cls(x, y, z, t))
+        wrapmethods, wrap, (x, y, z, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((p3.x, p3.y, p3.z, t)))
+        return wrapmethods(cls(x, y, z, t))
 
     @classmethod
     def from_cartesian(cls, x, y, z, t):
-        wrap, (x, y, z, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y, z, t)))
-        return wrap(cls(x, y, z, t))
+        wrapmethods, wrap, (x, y, z, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y, z, t)))
+        return wrapmethods(cls(x, y, z, t))
 
     @classmethod
     def from_spherical(cls, r, theta, phi, t):
-        wrap, (r, theta, phi, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((r, theta, phi, t)))
-        return wrap(cls.from_p3(uproot_methods.classes.TVector3.TVector3Array.from_spherical(r, theta, phi), t))
+        wrapmethods, wrap, (r, theta, phi, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((r, theta, phi, t)))
+        return wrapmethods(cls.from_p3(uproot_methods.classes.TVector3.TVector3Array.from_spherical(r, theta, phi), t))
 
     @classmethod
     def from_cylindrical(cls, rho, phi, z, t):
-        wrap, (rho, phi, z, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((rho, phi, z, t)))
-        return wrap(cls.from_p3(uproot_methods.classes.TVector3.TVector3Array.from_cylindrical(rho, phi, z), t))
+        wrapmethods, wrap, (rho, phi, z, t) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((rho, phi, z, t)))
+        return wrapmethods(cls.from_p3(uproot_methods.classes.TVector3.TVector3Array.from_cylindrical(rho, phi, z), t))
 
     @classmethod
     def from_xyzm(cls, x, y, z, m):
-        wrap, (x, y, z, m) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y, z, m)))
-        return wrap(cls(x, y, z, awkward.util.numpy.sqrt(x*x + y*y + z*z + m*m*awkward.util.numpy.sign(m))))
+        wrapmethods, wrap, (x, y, z, m) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y, z, m)))
+        return wrapmethods(cls(x, y, z, awkward.util.numpy.sqrt(x*x + y*y + z*z + m*m*awkward.util.numpy.sign(m))))
 
     @classmethod
     def from_ptetaphi(cls, pt, eta, phi, energy):
-        wrap, (pt, eta, phi, energy) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((pt, eta, phi, energy)))
-        return wrap(cls(pt * awkward.util.numpy.cos(phi),
-                        pt * awkward.util.numpy.sin(phi),
-                        pt * awkward.util.numpy.sinh(eta),
-                        energy))
+        wrapmethods, wrap, (pt, eta, phi, energy) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((pt, eta, phi, energy)))
+        out = wrapmethods(cls(pt * awkward.util.numpy.cos(phi),
+                              pt * awkward.util.numpy.sin(phi),
+                              pt * awkward.util.numpy.sinh(eta),
+                              energy))
+        out._memo_pt = wrap(pt)
+        out._memo_eta = wrap(eta)
+        out._memo_phi = wrap(phi)
+        return out
 
     @classmethod
     def from_ptetaphim(cls, pt, eta, phi, mass):
-        wrap, (pt, eta, phi, mass) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((pt, eta, phi, mass)))
+        wrapmethods, wrap, (pt, eta, phi, mass) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((pt, eta, phi, mass)))
         x = pt * awkward.util.numpy.cos(phi)
         y = pt * awkward.util.numpy.sin(phi)
         z = pt * awkward.util.numpy.sinh(eta)
         p3 = uproot_methods.classes.TVector3.TVector3Array(x, y, z)
-        return wrap(cls.from_p3(p3, awkward.util.numpy.sqrt(x*x + y*y + z*z + mass*mass*awkward.util.numpy.sign(mass))))
+        out = wrapmethods(cls.from_p3(p3, awkward.util.numpy.sqrt(x*x + y*y + z*z + mass*mass*awkward.util.numpy.sign(mass))))
+        out._memo_pt = wrap(pt)
+        out._memo_eta = wrap(eta)
+        out._memo_phi = wrap(phi)
+        out._memo_mass = wrap(mass)
+        return out
 
     @property
     def x(self):

--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -39,18 +39,6 @@ import uproot_methods.base
 import uproot_methods.common.TVector
 import uproot_methods.classes.TVector3
 
-# TODO: put into utility submodule
-# Inheirit from read-only property?
-class memoized(object):
-    def __init__(self, fn):
-        self._fn = fn
-        self._name = "_memoized_" + fn.__name__
-
-    def __call__(self, fn_classinstance):
-        if getattr(fn_classinstance, self._name, None) is None:
-            setattr(fn_classinstance, self._name, self._fn(fn_classinstance))
-        return getattr(fn_classinstance, self._name)
-
 class Common(object):
     @property
     def E(self):
@@ -88,7 +76,7 @@ class Common(object):
         return self.p3.rho2
 
     @property
-    @memoized
+    @uproot_methods.base.memo
     def pt(self):
         return self.p3.rho
 
@@ -105,7 +93,7 @@ class Common(object):
         return self.mag2
 
     @property
-    @memoized
+    @uproot_methods.base.memo
     def mass(self):
         return self.mag
 
@@ -114,7 +102,7 @@ class Common(object):
         return self.energy**2 - self.z**2
         
     @property
-    @memoized
+    @uproot_methods.base.memo
     def phi(self):
         return self.p3.phi
 
@@ -216,9 +204,9 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
         return awkward.util.numpy.sqrt(awkward.util.numpy.absolute(mt2)) * sign
 
     @property
-    @memoized
+    @uproot_methods.base.memo
     def eta(self):
-        return awkward.util.numpy.arcsinh(self.z / self.p3.rho)
+        return awkward.util.numpy.arcsinh(self.z / awkward.util.numpy.sqrt(self.x**2 + self.y**2))
 
     @property
     def rapidity(self):
@@ -396,7 +384,7 @@ class Methods(Common, uproot_methods.base.ROOTMethods):
 
     @property
     def eta(self):
-        return math.asinh(self.z / self.p3.rho)
+        return math.asinh(self.z / math.sqrt(self.x**2 + self.y**2))
 
     @property
     def rapidity(self):

--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -39,6 +39,18 @@ import uproot_methods.base
 import uproot_methods.common.TVector
 import uproot_methods.classes.TVector3
 
+# TODO: put into utility submodule
+# Inheirit from read-only property?
+class memoized(object):
+    def __init__(self, fn):
+        self._fn = fn
+        self._name = "_memoized_" + fn.__name__
+
+    def __call__(self, fn_classinstance):
+        if getattr(fn_classinstance, self._name, None) is None:
+            setattr(fn_classinstance, self._name, self._fn(fn_classinstance))
+        return getattr(fn_classinstance, self._name)
+
 class Common(object):
     @property
     def E(self):
@@ -76,6 +88,7 @@ class Common(object):
         return self.p3.rho2
 
     @property
+    @memoized
     def pt(self):
         return self.p3.rho
 
@@ -92,6 +105,7 @@ class Common(object):
         return self.mag2
 
     @property
+    @memoized
     def mass(self):
         return self.mag
 
@@ -100,6 +114,7 @@ class Common(object):
         return self.energy**2 - self.z**2
         
     @property
+    @memoized
     def phi(self):
         return self.p3.phi
 
@@ -201,6 +216,7 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
         return awkward.util.numpy.sqrt(awkward.util.numpy.absolute(mt2)) * sign
 
     @property
+    @memoized
     def eta(self):
         return awkward.util.numpy.arcsinh(self.z / self.p3.rho)
 

--- a/uproot_methods/classes/TVector2.py
+++ b/uproot_methods/classes/TVector2.py
@@ -153,14 +153,14 @@ class TVector2Array(ArrayMethods, awkward.ObjectArray):
 
     @classmethod
     def from_cartesian(cls, x, y):
-        wrap, (x, y) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y)))
-        return wrap(cls(x, y))
+        wrapmethods, wrap, (x, y) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y)))
+        return wrapmethods(cls(x, y))
 
     @classmethod
     def from_polar(cls, rho, phi):
-        wrap, (rho, phi) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((rho, phi)))
-        return wrap(cls(rho * awkward.util.numpy.cos(phi),
-                        rho * awkward.util.numpy.sin(phi)))
+        wrapmethods, wrap, (rho, phi) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((rho, phi)))
+        return wrapmethods(cls(rho * awkward.util.numpy.cos(phi),
+                               rho * awkward.util.numpy.sin(phi)))
 
     @property
     def x(self):

--- a/uproot_methods/classes/TVector3.py
+++ b/uproot_methods/classes/TVector3.py
@@ -267,22 +267,22 @@ class TVector3Array(ArrayMethods, awkward.ObjectArray):
 
     @classmethod
     def from_cartesian(cls, x, y, z):
-        wrap, (x, y, z) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y, z)))
-        return wrap(cls(x, y, z))
+        wrapmethods, wrap, (x, y, z) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((x, y, z)))
+        return wrapmethods(cls(x, y, z))
 
     @classmethod
     def from_spherical(cls, r, theta, phi):
-        wrap, (r, theta, phi) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((r, theta, phi)))
-        return wrap(cls(r * awkward.util.numpy.sin(theta) * awkward.util.numpy.cos(phi),
-                        r * awkward.util.numpy.sin(theta) * awkward.util.numpy.sin(phi),
-                        r * awkward.util.numpy.cos(theta)))
+        wrapmethods, wrap, (r, theta, phi) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((r, theta, phi)))
+        return wrapmethods(cls(r * awkward.util.numpy.sin(theta) * awkward.util.numpy.cos(phi),
+                               r * awkward.util.numpy.sin(theta) * awkward.util.numpy.sin(phi),
+                               r * awkward.util.numpy.cos(theta)))
 
     @classmethod
     def from_cylindrical(cls, rho, phi, z):
-        wrap, (rho, phi, z) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((rho, phi, z)))
-        return wrap(cls(rho * awkward.util.numpy.cos(phi),
-                        rho * awkward.util.numpy.sin(phi),
-                        z))
+        wrapmethods, wrap, (rho, phi, z) = uproot_methods.base._unwrap_jagged(ArrayMethods, uproot_methods.base._normalize_arrays((rho, phi, z)))
+        return wrapmethods(cls(rho * awkward.util.numpy.cos(phi),
+                               rho * awkward.util.numpy.sin(phi),
+                               z))
 
     @property
     def x(self):

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
A small improvement in eta evaluation using `asinh` (`atanh` would save a `pt` call but it would be numerically imprecise at large `z` due to the asymptote)
```python
entries = 70000
p3 = np.random.uniform(0, 20, size=entries*3).reshape(-1,3)
E = np.sqrt(np.sum(p3**2, axis=1))
p4 = uproot_methods.TLorentzVectorArray(p3[:,0], p3[:,1], p3[:,2], E)

%timeit p4.eta
```
gives
```
Old: 5.79 ms ± 223 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New: 2.53 ms ± 114 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
I also made a `memoized` decorator class, but I'm not sure if this is the correct idiom.  Consider it WIP for now