### PR TITLE
adding test for TH1 and fixing from_numpy

### DIFF
--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -43,6 +43,7 @@ class Test(unittest.TestCase):
 
         h = from_numpy((values, edges))
 
+        assert h.name is None
         assert h.numbins == 2
         assert h.title == b""
         assert h.low == 0

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -43,7 +43,6 @@ class Test(unittest.TestCase):
 
         h = from_numpy((values, edges))
 
-        assert h.name
         assert h.numbins == 2
         assert h.title == b""
         assert h.low == 0

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2018, DIANA-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import numpy as np
+
+class Test(unittest.TestCase):
+    def runTest(self):
+        pass
+
+    def test_th1(self):
+        from uproot_methods.classes.TH1 import Methods, _histtype, from_numpy
+
+        edges = np.array((0., 1., 2.))
+        values = np.array([2, 3])
+
+        h = from_numpy((values, edges))
+
+        assert h.name
+        assert h.numbins == 2
+        assert h.title == b""
+        assert h.low == 0
+        assert h.high == 2
+        assert h.underflows == 0
+        assert h.overflows == 0
+
+        np.testing.assert_equal(h.edges, edges)
+        np.testing.assert_equal(h.values, values)
+        np.testing.assert_equal(h.variances, values ** 2)
+
+        np.testing.assert_equal(h.alledges, [-np.inf] + list(edges) + [np.inf])
+        np.testing.assert_equal(h.allvalues, [0] + list(values) + [0])
+        np.testing.assert_equal(h.allvariances, [0] + list(values ** 2) + [0])
+
+        np.testing.assert_equal(h.bins, ((0, 1), (1, 2)))
+        np.testing.assert_equal(h.allbins, ((-np.inf, 0), (0, 1), (1, 2), (2, np.inf)))
+
+        assert h.interval(0) == (-np.inf, 0)
+        assert h.interval(1) == (0, 1)
+        assert h.interval(2) == (1, 2)
+        assert h.interval(3) == (2, np.inf)
+        assert h.interval(-1) == h.interval(3)

--- a/uproot_methods/classes/TH1.py
+++ b/uproot_methods/classes/TH1.py
@@ -131,7 +131,7 @@ class Methods(uproot_methods.base.ROOTMethods):
             return (float("-inf"), low)
         elif index == len(self) - 1:
             return (high, float("inf"))
-        elif len(self._fXaxis._fXbins) == self._fXaxis._fNbins + 1:
+        elif len(getattr(self._fXaxis, "_fXbins", [])) == self._fXaxis._fNbins + 1:
             return (self._fXaxis._fXbins[index - 1], self._fXaxis._fXbins[index])
         else:
             norm = (high - low) / self._fXaxis._fNbins
@@ -366,10 +366,13 @@ def from_numpy(histogram):
 
     class TAxis(object):
         def __init__(self, edges):
-            self._fNbins = len(edges)-1
+            self._fNbins = len(edges) - 1
             self._fXmin = edges[0]
             self._fXmax = edges[-1]
-            self._fXbins = edges.astype(">f8")
+            if numpy.array_equal(edges, numpy.linspace(self._fXmin, self._fXmax, len(edges), dtype=edges.dtype)):
+                self._fXbins = numpy.array([], dtype=">f8")
+            else:
+                self._fXbins = edges.astype(">f8")
 
     out = TH1.__new__(TH1)
     out._fXaxis = TAxis(edges)
@@ -384,7 +387,6 @@ def from_numpy(histogram):
     else:
         out._fTitle = b""
 
-    out._fName = "h%i" % id(histogram)
     out._classname, content = _histtype(content)
 
     valuesarray = numpy.empty(len(content) + 2, dtype=content.dtype)

--- a/uproot_methods/classes/TH1.py
+++ b/uproot_methods/classes/TH1.py
@@ -2,21 +2,21 @@
 
 # Copyright (c) 2018, DIANA-HEP
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the following disclaimer in the documentation
 #   and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the copyright holder nor the names of its
 #   contributors may be used to endorse or promote products derived from
 #   this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -365,15 +365,14 @@ def from_numpy(histogram):
         pass
 
     class TAxis(object):
-        def __init__(self, fNbins, fXmin, fXmax):
-            self._fNbins = fNbins
-            self._fXmin = fXmin
-            self._fXmax = fXmax
+        def __init__(self, edges):
+            self._fNbins = len(edges)-1
+            self._fXmin = edges[0]
+            self._fXmax = edges[-1]
+            self._fXbins = edges.astype(">f8")
 
     out = TH1.__new__(TH1)
-    out._fXaxis = TAxis(len(edges) - 1, edges[0], edges[-1])
-    if not numpy.array_equal(edges, numpy.linspace(edges[0], edges[-1], len(edges), dtype=edges.dtype)):
-        out._fXaxis._fXbins = edges.astype(">f8")
+    out._fXaxis = TAxis(edges)
 
     centers = (edges[:-1] + edges[1:]) / 2.0
     out._fEntries = out._fTsumw = out._fTsumw2 = content.sum()
@@ -385,6 +384,7 @@ def from_numpy(histogram):
     else:
         out._fTitle = b""
 
+    out._fName = "h%i" % id(histogram)
     out._classname, content = _histtype(content)
 
     valuesarray = numpy.empty(len(content) + 2, dtype=content.dtype)

--- a/uproot_methods/classes/TH1.py
+++ b/uproot_methods/classes/TH1.py
@@ -46,7 +46,7 @@ class Methods(uproot_methods.base.ROOTMethods):
 
     @property
     def name(self):
-        return self._fName
+        return getattr(self._fName, None)
 
     @property
     def title(self):

--- a/uproot_methods/classes/TH1.py
+++ b/uproot_methods/classes/TH1.py
@@ -46,7 +46,7 @@ class Methods(uproot_methods.base.ROOTMethods):
 
     @property
     def name(self):
-        return getattr(self._fName, None)
+        return getattr(self, "_fName", None)
 
     @property
     def title(self):


### PR DESCRIPTION
I am adding a basic test of the interface of a TH1 histogram generated via the `from_numpy` method.

I am using `from_numpy` so that I don't have to generate a mock histogram myself, but it would be better to split this test in two. I think a small binary file should be added to the repository which contains a ROOT histogram with known layout, so that this can be read with uproot-methods and the interface checked.

I fixed a few more bugs in the output of `from_numpy`, but more remain (I will add more issues).