### PR TITLE
Make _unwrap_jagged deal with masked JaggedArrays

### DIFF
--- a/uproot_methods/base.py
+++ b/uproot_methods/base.py
@@ -85,11 +85,8 @@ class ROOTMethods(awkward.Methods):
             else:
                 awkcls = ArrayMethods.mixin(ArrayMethods, cls.awkward.JaggedArray)
             counts = arrays[0].stops - arrays[0].starts
-            if hasattr(awkcls, "counts2startsstops"):
-                starts, stops = awkcls.counts2startsstops(arrays[0].counts)
-            else:
-                offsets = awkcls.counts2offsets(arrays[0].counts)
-                starts, stops = offsets[:-1], offsets[1:]
+            offsets = awkcls.counts2offsets(arrays[0].counts)
+            starts, stops = offsets[:-1], offsets[1:]
             wrap, arrays = cls._unwrap_jagged(ArrayMethods, [x.flatten() for x in arrays])
             return lambda x: awkcls(starts, stops, wrap(x)), arrays
 

--- a/uproot_methods/base.py
+++ b/uproot_methods/base.py
@@ -85,8 +85,11 @@ class ROOTMethods(awkward.Methods):
             else:
                 awkcls = ArrayMethods.mixin(ArrayMethods, cls.awkward.JaggedArray)
             counts = arrays[0].stops - arrays[0].starts
-            starts = awkward.numpy.cumsum(counts) - counts[0]
-            stops = starts + counts
+            if hasattr(awkcls, "counts2startsstops"):
+                starts, stops = awkcls.counts2startsstops(arrays[0].counts)
+            else:
+                offsets = awkcls.counts2offsets(arrays[0].counts)
+                starts, stops = offsets[:-1], offsets[1:]
             wrap, arrays = cls._unwrap_jagged(ArrayMethods, [x.flatten() for x in arrays])
             return lambda x: awkcls(starts, stops, wrap(x)), arrays
 

--- a/uproot_methods/base.py
+++ b/uproot_methods/base.py
@@ -84,8 +84,10 @@ class ROOTMethods(awkward.Methods):
                 awkcls = cls.awkward.JaggedArray
             else:
                 awkcls = ArrayMethods.mixin(ArrayMethods, cls.awkward.JaggedArray)
-            starts, stops = arrays[0].starts, arrays[0].stops
-            wrap, arrays = cls._unwrap_jagged(ArrayMethods, [x.content for x in arrays])
+            counts = arrays[0].stops - arrays[0].starts
+            starts = awkward.numpy.cumsum(counts) - counts[0]
+            stops = starts + counts
+            wrap, arrays = cls._unwrap_jagged(ArrayMethods, [x.flatten() for x in arrays])
             return lambda x: awkcls(starts, stops, wrap(x)), arrays
 
     def _trymemo(self, name, function):

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Hi Jim!

I just came to try out your jet cleaning example from awkward, which is a very nice proof of concept! When I tried the TLorentzVector out however, it did not work for my use case. After some digging through the awkward, uproot_methods and uproot trinity I found the issue:

In the `_unwrap_jagged` function in uproot_methods/base.py, it is assumed that the awkward arrays are let's say "contiguous" and all have the same starts/stops structure, which is extracted from the first of the unwrapped arrays. Also, it uses `JaggedArray.content` instead of `JaggedArray.flatten()`, which gives you all the elements in the underlying numpy array even if they are masked. So if you have some events with electrons let's say, then do some event selection and then some Tag n' Probe with the masked electrons, you'll get in trouble.

I suggest here a hotfix as a start, but I'm not really sure if this is the final solution :) I think it might be better to change the interface of the JaggedArray instead. The `contens`, `starts` and `stops` should not really be used publicly I think, since they depend on the internal state of the JaggedArray. However, they are @properties and don't start with an underscore so it looks like they are public. I guess all I'm saying is that all public properties (don't starting with an underscore) should be independent of if the array is contiguous or not.

Are you aware of these issues? Is there anything else I can do to help with this?

By the way our last discussion was very fruitful for me, as you showed me the power of decorators! I am right now developing my own Python analysis framework which got a lot more beautiful with decorators (for example here [1]). It might remind a bit of CMSSW though :D

Cheers,
Jonas

[1] https://github.com/guitargeek/MultileptonAnalysis/blob/master/python/geeksw_analysis/producers/ParticleLoader.py 