### PR TITLE
Persistable physics vector arrays

### DIFF
--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -149,6 +149,16 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: TLorentzVector(row["fX"], row["fY"], row["fZ"], row["fE"]))
 
+    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+        self._valid()
+        x, y, z, t = self.x, self.y, self.z, self.t
+        return {"id": ident,
+                "call": ["uproot_methods.classes.TLorentzVector", "TLorentzVectorArray", "from_cartesian"],
+                "args": [fill(x, "TLorentzVectorArray.x", prefix, suffix, schemasuffix, storage, compression, **kwargs),
+                         fill(y, "TLorentzVectorArray.y", prefix, suffix, schemasuffix, storage, compression, **kwargs),
+                         fill(z, "TLorentzVectorArray.z", prefix, suffix, schemasuffix, storage, compression, **kwargs),
+                         fill(t, "TLorentzVectorArray.t", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+
     @property
     def p3(self):
         out = self.empty_like(generator=lambda row: uproot_methods.classes.TVector3.TVector3(row["fX"], row["fY"], row["fZ"]))

--- a/uproot_methods/classes/TVector2.py
+++ b/uproot_methods/classes/TVector2.py
@@ -49,6 +49,14 @@ class ArrayMethods(Common, uproot_methods.common.TVector.ArrayMethods, uproot_me
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: TVector2(row["fX"], row["fY"]))
 
+    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+        self._valid()
+        x, y = self.x, self.y
+        return {"id": ident,
+                "call": ["uproot_methods.classes.TVector2", "TVector2Array", "from_cartesian"],
+                "args": [fill(x, "TVector2Array.x", prefix, suffix, schemasuffix, storage, compression, **kwargs),
+                         fill(y, "TVector2Array.y", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+
     @property
     def x(self):
         return self["fX"]

--- a/uproot_methods/classes/TVector3.py
+++ b/uproot_methods/classes/TVector3.py
@@ -108,6 +108,15 @@ class ArrayMethods(Common, uproot_methods.common.TVector.ArrayMethods, uproot_me
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: TVector3(row["fX"], row["fY"], row["fZ"]))
 
+    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+        self._valid()
+        x, y, z = self.x, self.y, self.z
+        return {"id": ident,
+                "call": ["uproot_methods.classes.TVector3", "TVector3Array", "from_cartesian"],
+                "args": [fill(x, "TVector3Array.x", prefix, suffix, schemasuffix, storage, compression, **kwargs),
+                         fill(y, "TVector3Array.y", prefix, suffix, schemasuffix, storage, compression, **kwargs),
+                         fill(z, "TVector3Array.z", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+
     @property
     def x(self):
         return self["fX"]

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Give TLorentzVectorArray, TVector3Array, TVector2Array `__awkward_persist__` methods so that they can be saved to and read from files.