### PR TITLE
Add from_numpy method to TH2

### DIFF
--- a/uproot_methods/convert.py
+++ b/uproot_methods/convert.py
@@ -26,6 +26,9 @@ def towriteable(obj):
         if any(x == ("builtins", "bytes") or x == ("builtins", "str") or x == ("__builtin__", "str") or x == ("__builtin__", "unicode") for x in types(obj.__class__, obj)):
             return (None, None, "uproot.write.objects.TObjString", "TObjString")
 
+        elif isinstance(obj, tuple) and any(x[:2] == ("numpy", "ndarray") for x in types(obj[0].__class__, obj[0])) and any(x[:2] == ("numpy", "ndarray") for x in types(obj[1].__class__, obj[1])) and obj[0].shape == (len(obj[1])-1, len(obj[2])-1):
+            return ("uproot_methods.classes.TH2", "from_numpy", "uproot.write.objects.TH", "TH")
+
         elif isinstance(obj, tuple) and any(x[:2] == ("numpy", "ndarray") for x in types(obj[0].__class__, obj[0])) and any(x[:2] == ("numpy", "ndarray") for x in types(obj[1].__class__, obj[1])) and len(obj[0]) + 1 == len(obj[1]):
             return ("uproot_methods.classes.TH1", "from_numpy", "uproot.write.objects.TH", "TH")
 
@@ -36,6 +39,9 @@ def towriteable(obj):
             return ("uproot_methods.classes.TH1", "from_physt", "uproot.write.objects.TH", "TH")
 
         elif any(x == ("uproot_methods.classes.TH1", "Methods") or x == ("TH1", "Methods") for x in types(obj.__class__, obj)):
+            return (None, None, "uproot.write.objects.TH", "TH")
+
+        elif any(x == ("uproot_methods.classes.TH2", "Methods") or x == ("TH2", "Methods") for x in types(obj.__class__, obj)):
             return (None, None, "uproot.write.objects.TH", "TH")
 
         else:


### PR DESCRIPTION
Adds ability to write 2D histograms created using np.histogram2d. 

Changes:

1. `from_numpy()` method added to `classes.TH2`
2. Necessary additions to `convert.towriteable()` for directly writing to file

```python
f = uproot.create("file.root")
data = np.random.normal(0, 1, (10000, 2))
f['hist']= np.histogram2d(data[:,0], data[:,1], bins=(50, 50), range=((-5, 5), (-5, 5)))
f.close()
```