### PR TITLE
Awkward lazyarrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - pip install $NUMPY
   - if [[ $TRAVIS_PYTHON_VERSION = pypy* ]] ; then pip install "numpy<1.16.0" ; fi       # FIXME: pypy bug in numpy
   - python -c 'import numpy; print(numpy.__version__)'
-  - pip install "awkward>=0.9.0"
+  - pip install "awkward>=0.10.0"
   - python -c 'import awkward; print(awkward.__version__)'
   - pip install pytest pytest-runner
   - pip install --upgrade pyOpenSSL     # for deployment

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Dependencies:
 -------------
 
 - `numpy <https://scipy.org/install.html>`__ (1.13.1+)
-- `awkward-array <https://github.com/scikit-hep/awkward-array>`__ (0.9.0+)
+- `awkward-array <https://github.com/scikit-hep/awkward-array>`__ (0.10.0+)
 
 .. inclusion-marker-3-do-not-remove
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,6 @@ install:
 build_script:
   - "pip install %NUMPY%"
   - "pip install pytest pytest-runner"
-  - "pip install \"awkward>=0.9.0\""
+  - "pip install \"awkward>=0.10.0\""
   - "python -c \"import awkward; print(awkward.__version__)\""
   - "pytest -v tests"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy>=1.13.1
-awkward>=0.9.0
+awkward>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name = "uproot-methods",
       download_url = "https://github.com/scikit-hep/uproot-methods/releases",
       license = "BSD 3-clause",
       test_suite = "tests",
-      install_requires = ["numpy>=1.13.1", "awkward>=0.9.0"],
+      install_requires = ["numpy>=1.13.1", "awkward>=0.10.0"],
       tests_require = [],
       classifiers = [
           "Development Status :: 4 - Beta",

--- a/uproot_methods/profiles/__init__.py
+++ b/uproot_methods/profiles/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot-methods/blob/master/LICENSE
+
+import importlib
+import re
+
+def transformer(name):
+    m = re.match("^([a-zA-Z_][a-zA-Z_0-9]*)(\.[a-zA-Z_][a-zA-Z_0-9]*)*$", name)
+    if m is None:
+        raise ValueError("profile name must match \"identifier(.identifier)*\"")
+    return getattr(importlib.import_module("uproot_methods.profiles." + m.string), "transform")

--- a/uproot_methods/profiles/cms/__init__.py
+++ b/uproot_methods/profiles/cms/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot-methods/blob/master/LICENSE

--- a/uproot_methods/profiles/cms/nanoaod.py
+++ b/uproot_methods/profiles/cms/nanoaod.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot-methods/blob/master/LICENSE
+
+def transform(array):
+    raise NotImplementedError

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
This will be uproot-methods 0.6.0, taking awkward 0.10.0 as a minimal version. It includes PR #55 and (empty) registration for experiment-specific lazy array profiles.