### PR TITLE
Generalize "pandas" method to support TH2

### DIFF
--- a/uproot_methods/classes/TH2.py
+++ b/uproot_methods/classes/TH2.py
@@ -197,61 +197,6 @@ class Methods(uproot_methods.base.ROOTMethods):
         else:
             return [str(x) for x in self._fYaxis._fLabels]
 
-    def pandas(self, underflow=True, overflow=True, variance=True):
-        def flow(x):
-            if not underflow and not overflow:
-                return x[1:-1]
-            elif not underflow:
-                return x[1:]
-            elif not overflow:
-                return x[:-1]
-            return x
-
-        def flow2d(x):
-            if not underflow and not overflow:
-                return x[1:-1, 1:-1]
-            elif not underflow:
-                return x[1:, 1:]
-            elif not overflow:
-                return x[:-1, -1]
-            return x
-
-        import pandas
-
-        x_bins, y_bins = self.allbins
-
-        x_bins = flow(x_bins)
-        y_bins = flow(y_bins)
-
-        n_x = len(x_bins)
-        n_y = len(y_bins)
-
-        x_bins_expanded = numpy.repeat(x_bins, n_y, axis=0)
-
-        y_bins_expanded = numpy.tile(y_bins, (n_x, 1))
-
-        data = dict(
-            x_min=x_bins_expanded[:, 0],
-            x_max=x_bins_expanded[:, 1],
-            y_min=y_bins_expanded[:, 0],
-            y_max=y_bins_expanded[:, 1],
-            value=flow2d(self.allvalues).flatten(),
-        )
-
-        columns = ["x_min", "x_max", "y_min", "y_max", "value"]
-
-        if variance:
-            data["variance"] = flow2d(self.allvariances).flatten()
-            columns += ["variance"]
-
-        bin_x_idx = numpy.repeat(numpy.arange(n_x), n_y)
-        bin_y_idx = numpy.tile(numpy.arange(n_y), n_x)
-
-        index = pandas.MultiIndex.from_tuples(list(zip(bin_x_idx, bin_y_idx)), names=["x_bin", "y_bin"])
-
-        return pandas.DataFrame(index=index, data=data, columns=columns)
-
-
 def _histtype(content):
     if issubclass(content.dtype.type, (numpy.bool_, numpy.bool)):
         return b"TH2C", content.astype(">i1")

--- a/uproot_methods/classes/TH2.py
+++ b/uproot_methods/classes/TH2.py
@@ -197,6 +197,61 @@ class Methods(uproot_methods.base.ROOTMethods):
         else:
             return [str(x) for x in self._fYaxis._fLabels]
 
+    def pandas(self, underflow=True, overflow=True, variance=True):
+        def flow(x):
+            if not underflow and not overflow:
+                return x[1:-1]
+            elif not underflow:
+                return x[1:]
+            elif not overflow:
+                return x[:-1]
+            return x
+
+        def flow2d(x):
+            if not underflow and not overflow:
+                return x[1:-1, 1:-1]
+            elif not underflow:
+                return x[1:, 1:]
+            elif not overflow:
+                return x[:-1, -1]
+            return x
+
+        import pandas
+
+        x_bins, y_bins = self.allbins
+
+        x_bins = flow(x_bins)
+        y_bins = flow(y_bins)
+
+        n_x = len(x_bins)
+        n_y = len(y_bins)
+
+        x_bins_expanded = numpy.repeat(x_bins, n_y, axis=0)
+
+        y_bins_expanded = numpy.tile(y_bins, (n_x, 1))
+
+        data = dict(
+            x_min=x_bins_expanded[:, 0],
+            x_max=x_bins_expanded[:, 1],
+            y_min=y_bins_expanded[:, 0],
+            y_max=y_bins_expanded[:, 1],
+            value=flow2d(self.allvalues).flatten(),
+        )
+
+        columns = ["x_min", "x_max", "y_min", "y_max", "value"]
+
+        if variance:
+            data["variance"] = flow2d(self.allvariances).flatten()
+            columns += ["variance"]
+
+        bin_x_idx = numpy.repeat(numpy.arange(n_x), n_y)
+        bin_y_idx = numpy.tile(numpy.arange(n_y), n_x)
+
+        index = pandas.MultiIndex.from_tuples(list(zip(bin_x_idx, bin_y_idx)), names=["x_bin", "y_bin"])
+
+        return pandas.DataFrame(index=index, data=data, columns=columns)
+
+
 def _histtype(content):
     if issubclass(content.dtype.type, (numpy.bool_, numpy.bool)):
         return b"TH2C", content.astype(">i1")


### PR DESCRIPTION
Hello!

I would really enjoy a method for the TH2 which converts it into a pandas data frame that is easily human-readable. This way we could compare the values in different TH2s with the same binning very quickly, which I would need to compare two dimensional scale factors for example.

Since a similar pandas function already exists for the TH1 in uproot-methods (which the TH2 inherits but that does not work there), I thought it might be good to push also my implementation for the TH2?

The pandas function for the TH1 gives you DataFrames like these:

![TH1_pandas](https://user-images.githubusercontent.com/6578603/62301820-91b34c00-b479-11e9-9ed5-c15d0cd9e798.png)

I did not really like this index with the bin edges, as it looks dangerous to use with floating point bin edges. I propose instead to have some MultiIndex with the bin indices for the TH2 case:

![TH2_pandas](https://user-images.githubusercontent.com/6578603/62301396-d5f21c80-b478-11e9-9383-4c314ce046a6.png)

And concerning the unit tests: can I easily create a TH2 without reading it from some ROOT file to implement a test?

What do you think?

Cheers,
Jonas