### PR TITLE
Maybe fixes issue #62.

### DIFF
--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -224,10 +224,16 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
 
         b2 = p3.mag2
         gamma = (1 - b2)**(-0.5)
-        gamma2 = self.awkward.numpy.zeros(b2.shape, dtype=self.awkward.numpy.float64)
-        mask = (b2 != 0)
-        gamma2[mask] = (gamma[mask] - 1) / b2[mask]
-        del mask
+
+        # b2 == 0  -->  gamma2 = nan
+        with self.awkward.numpy.errstate(divide="ignore"):
+            gamma2 = (gamma - 1) / b2
+
+        # but we want b2 == 0  -->  gamma2 = 0.5
+        if isinstance(gamma2, self.awkward.numpy.ndarray):
+            gamma2[self.awkward.numpy.isnan(gamma2)] = 0.5
+        else:
+            gamma2.fillna(0.5)
 
         bp = self.p3.dot(p3)
 

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Can't use a masked-assignment on non-Numpy arrays.

Also, the old code left unmasked entries _unassigned_! I think the limit of `gamma2` as `b2` → 0 is 0.5, but I hope @lukasheinrich can verify that.
