### PR TITLE
fix TH1 repr when _fName attr is not set

### DIFF
--- a/uproot_methods/classes/TH1.py
+++ b/uproot_methods/classes/TH1.py
@@ -12,7 +12,7 @@ import uproot_methods.base
 
 class Methods(uproot_methods.base.ROOTMethods):
     def __repr__(self):
-        if self._fName is None:
+        if self.name is None:
             return "<{0} at 0x{1:012x}>".format(self._classname, id(self))
         else:
             return "<{0} {1} 0x{2:012x}>".format(self._classname, repr(self._fName), id(self))


### PR DESCRIPTION
This is trying to fix:
```python
>>> import numpy as np
>>> hnp = np.histogram(range(10))
>>> from uproot_methods.classes.TH1 import from_numpy
>>> from_numpy(hnp)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/uscms_data/d3/wsi/lpcdm/uproot-methods/uproot_methods/classes/TH1.py", line 15, in __repr__
    if self._fName is None:
AttributeError: 'TH1' object has no attribute '_fName'
```