### PR TITLE
Fixes scikit-hep/awkward-array#169

### DIFF
--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -125,15 +125,15 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: TLorentzVector(row["fX"], row["fY"], row["fZ"], row["fE"]))
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
         x, y, z, t = self.x, self.y, self.z, self.t
-        return {"id": ident,
-                "call": ["uproot_methods.classes.TLorentzVector", "TLorentzVectorArray", "from_cartesian"],
-                "args": [fill(x, "TLorentzVectorArray.x", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(y, "TLorentzVectorArray.y", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(z, "TLorentzVectorArray.z", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(t, "TLorentzVectorArray.t", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+        return serializer.encode_call(
+            ["uproot_methods.classes.TLorentzVector", "TLorentzVectorArray", "from_cartesian"],
+            serializer(x, "TLorentzVectorArray.x"),
+            serializer(y, "TLorentzVectorArray.y"),
+            serializer(z, "TLorentzVectorArray.z"),
+            serializer(t, "TLorentzVectorArray.t"))
 
     @staticmethod
     def _wrapmethods(node, awkwardlib):
@@ -322,6 +322,16 @@ JaggedArrayMethods = ArrayMethods.mixin(ArrayMethods, awkward.JaggedArray)
 class PtEtaPhiMassArrayMethods(ArrayMethods):
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: PtEtaPhiMassLorentzVector(row["fPt"], row["fEta"], row["fPhi"], row["fMass"]))
+
+    def __awkward_serialize__(self, serializer):
+        self._valid()
+        pt, eta, phi, mass = self.pt, self.eta, self.phi, self.mass
+        return serializer.encode_call(
+            ["uproot_methods.classes.TLorentzVector", "TLorentzVectorArray", "from_ptetaphim"],
+            serializer(pt, "TLorentzVectorArray.pt"),
+            serializer(eta, "TLorentzVectorArray.eta"),
+            serializer(phi, "TLorentzVectorArray.phi"),
+            serializer(mass, "TLorentzVectorArray.mass"))
     
     @property
     def x(self):

--- a/uproot_methods/classes/TVector2.py
+++ b/uproot_methods/classes/TVector2.py
@@ -28,13 +28,13 @@ class ArrayMethods(Common, uproot_methods.common.TVector.ArrayMethods, uproot_me
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: TVector2(row["fX"], row["fY"]))
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
         x, y = self.x, self.y
-        return {"id": ident,
-                "call": ["uproot_methods.classes.TVector2", "TVector2Array", "from_cartesian"],
-                "args": [fill(x, "TVector2Array.x", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(y, "TVector2Array.y", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+        return serializer.encode_call(
+            ["uproot_methods.classes.TVector2", "TVector2Array", "from_cartesian"],
+            serializer(x, "TVector3Array.x"),
+            serializer(y, "TVector3Array.y"))
 
     @property
     def x(self):

--- a/uproot_methods/classes/TVector3.py
+++ b/uproot_methods/classes/TVector3.py
@@ -83,14 +83,14 @@ class ArrayMethods(Common, uproot_methods.common.TVector.ArrayMethods, uproot_me
     def _initObjectArray(self, table):
         self.awkward.ObjectArray.__init__(self, table, lambda row: TVector3(row["fX"], row["fY"], row["fZ"]))
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
         x, y, z = self.x, self.y, self.z
-        return {"id": ident,
-                "call": ["uproot_methods.classes.TVector3", "TVector3Array", "from_cartesian"],
-                "args": [fill(x, "TVector3Array.x", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(y, "TVector3Array.y", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(z, "TVector3Array.z", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+        return serializer.encode_call(
+            ["uproot_methods.classes.TVector3", "TVector3Array", "from_cartesian"],
+            serializer(x, "TVector3Array.x"),
+            serializer(y, "TVector3Array.y"),
+            serializer(z, "TVector3Array.z"))
 
     @property
     def x(self):

--- a/uproot_methods/version.py
+++ b/uproot_methods/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
This is the issue that is most directly related to scikit-hep/awkward-array#169.

The new serialization protocol introduced by scikit-hep/awkward-array#152 wasn't propagated through to uproot-methods.