### PR TITLE
Fix rotate_axis and similar methods in TLorentzVector

### DIFF
--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -74,6 +74,10 @@ class Test(unittest.TestCase):
         assert abs(a) == 7.043436661176133
         assert -a == TVector3(-4.4, -5.5, 0)
         assert +a == TVector3(4.4, 5.5, 0)
+        arot = a.rotatez(numpy.pi)
+        self.assertAlmostEqual(arot.x,-a.x)
+        self.assertAlmostEqual(arot.y,-a.y)
+        self.assertAlmostEqual(arot.z,a.z)
 
         a += TVector3(100, 200, 0)
         assert a == TVector3(104.4, 205.5, 0)
@@ -90,6 +94,11 @@ class Test(unittest.TestCase):
         assert (a + TVector3(1000, 2000, 0) == TVector3Array(numpy.full(10, 1000), numpy.arange(2000, 2010), numpy.zeros(10))).tolist() == [True, True, True, True, True, True, True, True, True, True]
         assert (a**2).tolist() == [0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0]
         assert (a**3).tolist() == [0.0, 1.0, 8.0, 27.0, 64.0, 125.0, 216.0, 343.0, 512.0, 729.0]
+        arot = a.rotatez(numpy.pi)
+        for aroti, ai in zip(arot.tolist(),a.tolist()):
+            self.assertAlmostEqual(aroti.x,-ai.x)
+            self.assertAlmostEqual(aroti.y,-ai.y)
+            self.assertAlmostEqual(aroti.z,ai.z)
 
     def test_vector3_jagged(self):
         TVector3Jagged = type("TVector3Jagged", (awkward.JaggedArray, uproot_methods.classes.TVector3.ArrayMethods), {})
@@ -102,6 +111,11 @@ class Test(unittest.TestCase):
         assert a.y.tolist() == [[0, 1, 2], [], [3, 4], [5, 6, 7, 8, 9]]
         assert (a + TVector3(1000, 2000, 0)).tolist() == [[TVector3(1000, 2000, 0), TVector3(1000, 2001, 0), TVector3(1000, 2002, 0)], [], [TVector3(1000, 2003, 0), TVector3(1000, 2004, 0)], [TVector3(1000, 2005, 0), TVector3(1000, 2006, 0), TVector3(1000, 2007, 0), TVector3(1000, 2008, 0), TVector3(1000, 2009, 0)]]
         assert (a + TVector3Array(numpy.full(4, 1000), numpy.arange(1000, 5000, 1000), numpy.zeros(4))).tolist() == [[TVector3(1000, 1000, 0), TVector3(1000, 1001, 0), TVector3(1000, 1002, 0)], [], [TVector3(1000, 3003, 0), TVector3(1000, 3004, 0)], [TVector3(1000, 4005, 0), TVector3(1000, 4006, 0), TVector3(1000, 4007, 0), TVector3(1000, 4008, 0), TVector3(1000, 4009, 0)]]
+        arot = a.rotatez(numpy.pi)
+        for aroti, ai in zip(arot.flatten().tolist(),a.flatten().tolist()):
+            self.assertAlmostEqual(aroti.x,-ai.x)
+            self.assertAlmostEqual(aroti.y,-ai.y)
+            self.assertAlmostEqual(aroti.z,ai.z)
 
     def test_lorentzvector(self):
         a = TLorentzVector(4.4, 5.5, 0, 0)
@@ -118,6 +132,11 @@ class Test(unittest.TestCase):
         assert abs(a + TLorentzVector(0, 0, 0, 10)) == 7.098591409568521
         assert -a == TLorentzVector(-4.4, -5.5, 0, 0)
         assert +a == TLorentzVector(4.4, 5.5, 0, 0)
+        arot = a.rotatez(numpy.pi)
+        self.assertAlmostEqual(arot.x,-a.x)
+        self.assertAlmostEqual(arot.y,-a.y)
+        self.assertAlmostEqual(arot.z,a.z)
+        assert arot.t == a.t
 
         a += TLorentzVector(100, 200, 0, 0)
         assert a == TLorentzVector(104.4, 205.5, 0, 0)
@@ -133,6 +152,12 @@ class Test(unittest.TestCase):
         assert (a + TLorentzVector(1000, 2000, 0, 0))[5] == TLorentzVector(1000, 2005, 0, 0)
         assert (a + TLorentzVector(1000, 2000, 0, 0) == TLorentzVectorArray(numpy.full(10, 1000), numpy.arange(2000, 2010), numpy.zeros(10), numpy.zeros(10))).tolist() == [True, True, True, True, True, True, True, True, True, True]
         assert (a**2).tolist() == [0.0, -1.0, -4.0, -9.0, -16.0, -25.0, -36.0, -49.0, -64.0, -81.0]
+        arot = a.rotatez(numpy.pi)
+        for aroti, ai in zip(arot.tolist(),a.tolist()):
+            self.assertAlmostEqual(aroti.x,-ai.x)
+            self.assertAlmostEqual(aroti.y,-ai.y)
+            self.assertAlmostEqual(aroti.z,ai.z)
+            assert aroti.t==ai.t
 
     def test_ptetaphim_array(self):
         a = TLorentzVectorArray.from_ptetaphim(
@@ -162,3 +187,9 @@ class Test(unittest.TestCase):
         assert a.y.tolist() == [[0, 1, 2], [], [3, 4], [5, 6, 7, 8, 9]]
         assert (a + TLorentzVector(1000, 2000, 0, 0)).tolist() == [[TLorentzVector(1000, 2000, 0, 0), TLorentzVector(1000, 2001, 0, 0), TLorentzVector(1000, 2002, 0, 0)], [], [TLorentzVector(1000, 2003, 0, 0), TLorentzVector(1000, 2004, 0, 0)], [TLorentzVector(1000, 2005, 0, 0), TLorentzVector(1000, 2006, 0, 0), TLorentzVector(1000, 2007, 0, 0), TLorentzVector(1000, 2008, 0, 0), TLorentzVector(1000, 2009, 0, 0)]]
         assert (a + TLorentzVectorArray(numpy.full(4, 1000), numpy.arange(1000, 5000, 1000), numpy.zeros(4), numpy.zeros(4))).tolist() == [[TLorentzVector(1000, 1000, 0, 0), TLorentzVector(1000, 1001, 0, 0), TLorentzVector(1000, 1002, 0, 0)], [], [TLorentzVector(1000, 3003, 0, 0), TLorentzVector(1000, 3004, 0, 0)], [TLorentzVector(1000, 4005, 0, 0), TLorentzVector(1000, 4006, 0, 0), TLorentzVector(1000, 4007, 0, 0), TLorentzVector(1000, 4008, 0, 0), TLorentzVector(1000, 4009, 0, 0)]]
+        arot = a.rotatez(numpy.pi)
+        for aroti, ai in zip(arot.flatten().tolist(),a.flatten().tolist()):
+            self.assertAlmostEqual(aroti.x,-ai.x)
+            self.assertAlmostEqual(aroti.y,-ai.y)
+            self.assertAlmostEqual(aroti.z,ai.z)
+            assert aroti.t==ai.t

--- a/uproot_methods/classes/TLorentzVector.py
+++ b/uproot_methods/classes/TLorentzVector.py
@@ -95,13 +95,13 @@ class Common(object):
         return self.p3._rotate_euler(phi, theta, psi), self.t
 
     def rotatex(self, angle):
-        return self.rotate_axis(TVector3(1.0, 0.0, 0.0), angle)
+        return self.rotate_axis(uproot_methods.classes.TVector3.TVector3(1.0, 0.0, 0.0), angle)
 
     def rotatey(self, angle):
-        return self.rotate_axis(TVector3(0.0, 1.0, 0.0), angle)
+        return self.rotate_axis(uproot_methods.classes.TVector3.TVector3(0.0, 1.0, 0.0), angle)
 
     def rotatez(self, angle):
-        return self.rotate_axis(TVector3(0.0, 0.0, 1.0), angle)
+        return self.rotate_axis(uproot_methods.classes.TVector3.TVector3(0.0, 0.0, 1.0), angle)
 
     def isspacelike(self, tolerance=1e-10):
         return self.mag2 < -tolerance
@@ -252,19 +252,21 @@ class ArrayMethods(Common, uproot_methods.base.ROOTMethods):
 
     def rotate_axis(self, axis, angle):
         p3, t = self._rotate_axis(axis, angle)
+        x, y, z = p3
         out = self.empty_like()
-        out["fX"] = p3.x
-        out["fY"] = p3.y
-        out["fZ"] = p3.z
+        out["fX"] = x
+        out["fY"] = y
+        out["fZ"] = z
         out["fE"] = t
         return out
 
     def rotate_euler(self, phi=0, theta=0, psi=0):
         p3, t = self._rotate_euler(phi, theta, psi)
+        x, y, z = p3
         out = self.empty_like()
-        out["fX"] = p3.x
-        out["fY"] = p3.y
-        out["fZ"] = p3.z
+        out["fX"] = x
+        out["fY"] = y
+        out["fZ"] = z
         out["fE"] = t
         return out
 
@@ -564,11 +566,13 @@ class Methods(Common, uproot_methods.base.ROOTMethods):
 
     def rotate_axis(self, axis, angle):
         p3, t = self._rotate_axis(axis, angle)
-        return self.__class__(p3.x, p3.y, p3.z, t)
+        x, y, z = p3
+        return self.__class__(x, y, z, t)
 
     def rotate_euler(self, phi=0, theta=0, psi=0):
         p3, t = self._rotate_euler(phi, theta, psi)
-        return self.__class__(p3.x, p3.y, p3.z, t)
+        x, y, z = p3
+        return self.__class__(x, y, z, t)
 
     def islightlike(self, tolerance=1e-10):
         return abs(self.mag2) < tolerance


### PR DESCRIPTION
This fixes an issue with the current version of rotate_axis (and similar methods) of TLorentzVector.
Currently the master will throw an error with the conversion of the tuple returned by TVector3 into the appropriate TLorentzVector type.
I've also added some unit tests for rotation.

You can test the results with
```
import uproot
import uproot_methods
import numpy
import numpy as np
import awkward

p4 = uproot_methods.TLorentzVector(0,1,0,1)
print(p4)
rot = p4.rotatex(np.pi)
print(rot)

px = [1,0,0]
py = [0,1,0]
pz = [0,0,1]
en = [1,1,1]

p4 = uproot_methods.TLorentzVectorArray(px,py,pz,en)
print(p4)
rot = p4.rotatex(np.pi)
print(rot)

px = awkward.fromiter([[1,0],[0]])
py = awkward.fromiter([[0,1],[0]])
pz = awkward.fromiter([[0,0],[1]])
en = awkward.fromiter([[1,1],[1]])

p4 = uproot_methods.TLorentzVectorArray.from_cartesian(px,py,pz,en)
print(p4)
rot = p4.rotatex(np.pi)
print(rot)
```

The output of which should be
```
TLorentzVector(x=0, y=1, z=0, t=1)
TLorentzVector(x=0, y=-1, z=1.2246e-16, t=1)
[TLorentzVector(x=1, y=0, z=0, t=1) TLorentzVector(x=0, y=1, z=0, t=1) TLorentzVector(x=0, y=0, z=1, t=1)]
[TLorentzVector(x=1, y=0, z=0, t=1) TLorentzVector(x=0, y=-1, z=1.2246e-16, t=1) TLorentzVector(x=0, y=-1.2246e-16, z=-1, t=1)]
[[TLorentzVector(x=1, y=0, z=0, t=1) TLorentzVector(x=0, y=1, z=0, t=1)] [TLorentzVector(x=0, y=0, z=1, t=1)]]
[[TLorentzVector(x=1, y=0, z=0, t=1) TLorentzVector(x=0, y=-1, z=1.2246e-16, t=1)] [TLorentzVector(x=0, y=-1.2246e-16, z=-1, t=1)]]
```