### PR TITLE
fix: Set from_numpy fSumw2 equal to entries

### DIFF
--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -27,11 +27,12 @@ class Test(unittest.TestCase):
 
         np.testing.assert_equal(h.edges, edges)
         np.testing.assert_equal(h.values, values)
-        np.testing.assert_equal(h.variances, values ** 2)
+        # Sumw2: variances equal the values
+        np.testing.assert_equal(h.variances, values)
 
         np.testing.assert_equal(h.alledges, [-np.inf] + list(edges) + [np.inf])
         np.testing.assert_equal(h.allvalues, [0] + list(values) + [0])
-        np.testing.assert_equal(h.allvariances, [0] + list(values ** 2) + [0])
+        np.testing.assert_equal(h.allvariances, [0] + list(values) + [0])
 
         np.testing.assert_equal(h.bins, ((0, 1), (1, 2)))
         np.testing.assert_equal(h.allbins, ((-np.inf, 0), (0, 1), (1, 2), (2, np.inf)))

--- a/uproot3_methods/classes/TH1.py
+++ b/uproot3_methods/classes/TH1.py
@@ -350,7 +350,8 @@ def from_numpy(histogram):
     valuesarray[-1] = 0
 
     out.extend(valuesarray)
-    out._fSumw2 = valuesarray ** 2
+    # variances equal the entries
+    out._fSumw2 = valuesarray
 
     return out
 


### PR DESCRIPTION
Resolves #97 given @henryiii's proposed solution.

> The call `hist.Sumw2(kTRUE)` [in ROOT] sets the variances equal to the entries. Then the error is the square root of the entries. Uproot is setting the variance equal to the square of the entries, making the error equal to the entries. I think it's a simple bug due to the fact "sumw2" has a square in it, so it looks like it should be set with a square.